### PR TITLE
Add special collection to push off copying as far as possible while maintaining filter validity.

### DIFF
--- a/src/main/java/com/cinchapi/common/collect/AnyMaps.java
+++ b/src/main/java/com/cinchapi/common/collect/AnyMaps.java
@@ -20,14 +20,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import com.cinchapi.common.base.AnyStrings;
 import com.cinchapi.common.base.Array;
 import com.cinchapi.common.base.Verify;
 import com.cinchapi.common.collect.lazy.JITFilterMap;
-import com.cinchapi.common.collect.lazy.JITFilterValuesMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/src/main/java/com/cinchapi/common/collect/AnyMaps.java
+++ b/src/main/java/com/cinchapi/common/collect/AnyMaps.java
@@ -20,9 +20,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+
 import com.cinchapi.common.base.AnyStrings;
 import com.cinchapi.common.base.Array;
 import com.cinchapi.common.base.Verify;
+import com.cinchapi.common.collect.lazy.JITFilterValuesMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -160,6 +163,10 @@ public final class AnyMaps {
      *            {@code into} map
      * @return the merged {@link Map}
      */
+
+    public static <T, Q> JITFilterValuesMap<T, Q> filterValuesJustInTime(Map<T, Q> x, BiPredicate<T, Q> check) {
+        return new JITFilterValuesMap<>(x);
+    }
     public static Map<String, Object> merge(Map<String, Object> into,
             Map<String, Object> from,
             BiFunction<Object, Object, Object> strategy) {

--- a/src/main/java/com/cinchapi/common/collect/AnyMaps.java
+++ b/src/main/java/com/cinchapi/common/collect/AnyMaps.java
@@ -166,9 +166,10 @@ public final class AnyMaps {
      * @return the merged {@link Map}
      */
 
-    public static <T, Q> JITFilterMap<T, Q> filterValuesJustInTime(Map<T, Q> x, Predicate<Q> check) {
+    public static <T, Q> Map<T, Q> filterValuesJustInTime(Map<T, Q> x, Predicate<Q> check) {
         return new JITFilterMap<>(x, check);
     }
+
     public static Map<String, Object> merge(Map<String, Object> into,
             Map<String, Object> from,
             BiFunction<Object, Object, Object> strategy) {

--- a/src/main/java/com/cinchapi/common/collect/AnyMaps.java
+++ b/src/main/java/com/cinchapi/common/collect/AnyMaps.java
@@ -21,10 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 import com.cinchapi.common.base.AnyStrings;
 import com.cinchapi.common.base.Array;
 import com.cinchapi.common.base.Verify;
+import com.cinchapi.common.collect.lazy.JITFilterMap;
 import com.cinchapi.common.collect.lazy.JITFilterValuesMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -164,8 +166,8 @@ public final class AnyMaps {
      * @return the merged {@link Map}
      */
 
-    public static <T, Q> JITFilterValuesMap<T, Q> filterValuesJustInTime(Map<T, Q> x, BiPredicate<T, Q> check) {
-        return new JITFilterValuesMap<>(x);
+    public static <T, Q> JITFilterMap<T, Q> filterValuesJustInTime(Map<T, Q> x, Predicate<Q> check) {
+        return new JITFilterMap<>(x, check);
     }
     public static Map<String, Object> merge(Map<String, Object> into,
             Map<String, Object> from,

--- a/src/main/java/com/cinchapi/common/collect/lazy/JITFilterMap.java
+++ b/src/main/java/com/cinchapi/common/collect/lazy/JITFilterMap.java
@@ -1,0 +1,143 @@
+package com.cinchapi.common.collect.lazy;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.*;
+
+public class JITFilterMap<Key, Value> implements Map<Key, Value> {
+    private final AtomicBoolean isOriginal = new AtomicBoolean(true);
+    private Map<Key, Value> map;
+    final private Predicate<Value> check;
+
+    public JITFilterMap(Map<Key, Value> x, Predicate<Value> check) {
+        this.map = x;
+        this.check = check;
+    }
+
+    @Nullable @Override public Value put(Key key, Value value) {
+        executeAndMaybeCreateNewMap(value, () -> map.put(key, value));
+        final Value lastValue = map.get(key);
+        if (isOriginal.get() && !check.test(value))
+            map = new HashMap<>(map);
+        map.put(key, value);
+        return lastValue;
+    }
+
+    @Override public void putAll(@NotNull Map<? extends Key, ? extends Value> m) {
+        m.forEach((k,v) -> {
+            if (isOriginal.get() && !(check.test(v))) {
+                map = new HashMap<>(map);
+                isOriginal.set(false);
+            }
+            map.put(k, v);
+        });
+    }
+
+    @Override
+    public boolean replace(Key key, Value oldValue, Value newValue) {
+        AtomicBoolean
+        return map.replace(key, oldValue, newValue);
+    }
+
+    @Nullable
+    @Override
+    public Value replace(Key key, Value value) { return map.replace(key, value); }
+
+    @Override
+    public void replaceAll(BiFunction<? super Key, ? super Value, ? extends Value> function) {
+        map.replaceAll(function);
+    }
+
+    @Nullable
+    @Override
+    public Value putIfAbsent(Key key, Value value) { return map.putIfAbsent(key, value); }
+
+    private <T> T executeAndMaybeCreateNewMap(Value value, Supplier<T> alwaysRun) {
+        if (isOriginal.get() && !check.test(value)) {
+            map = new HashMap<>(map);
+            isOriginal.set(false);
+        }
+        return alwaysRun.get();
+    }
+    // ~~ Simple method delegation below this line ~~
+
+    @Override
+    public int size() { return map.size(); }
+
+    @Override
+    public boolean isEmpty() { return map.isEmpty(); }
+
+    @Override
+    public boolean containsKey(Object key) { return map.containsKey(key); }
+
+    @Override
+    public boolean containsValue(Object value) { return map.containsValue(value); }
+
+    @Override
+    public Value get(Object key) { return map.get(key); }
+
+    @Override
+    public Value remove(Object key) { return map.remove(key); }
+
+    @Override
+    public void clear() { map.clear(); }
+
+    @NotNull
+    @Override
+    public Set<Key> keySet() { return map.keySet(); }
+
+    @NotNull
+    @Override
+    public Collection<Value> values() { return map.values(); }
+
+    @NotNull
+    @Override
+    public Set<Entry<Key, Value>> entrySet() { return map.entrySet(); }
+
+    @Override
+    public boolean equals(Object o) { return map.equals(o); }
+
+    @Override
+    public int hashCode() { return map.hashCode(); }
+
+    @Override
+    public Value getOrDefault(Object key, Value defaultValue) { return map.getOrDefault(key, defaultValue); }
+
+    @Override
+    public void forEach(BiConsumer<? super Key, ? super Value> action) { map.forEach(action); }
+
+
+    @Override
+    public boolean remove(Object key, Object value) { return map.remove(key, value); }
+
+
+
+    @Override
+    public Value computeIfAbsent(Key key, Function<? super Key, ? extends Value> mappingFunction) {
+        return map.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public Value computeIfPresent(Key key, BiFunction<? super Key, ? super Value, ? extends Value> remappingFunction) {
+        return map.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public Value compute(Key key, BiFunction<? super Key, ? super Value, ? extends Value> remappingFunction) {
+        return map.compute(key, remappingFunction);
+    }
+
+    @Override
+    public Value merge(Key key, Value value,
+                       BiFunction<? super Value, ? super Value, ? extends Value> remappingFunction) {
+        return map.merge(key, value, remappingFunction);
+    }
+
+
+}

--- a/src/main/java/com/cinchapi/common/collect/lazy/JITFilterMap.java
+++ b/src/main/java/com/cinchapi/common/collect/lazy/JITFilterMap.java
@@ -158,8 +158,4 @@ public class JITFilterMap<Key, Value> implements Map<Key, Value> {
 
     @Override
     public boolean remove(Object key, Object value) { return map.remove(key, value); }
-
-
-
-
 }


### PR DESCRIPTION
http://jira.cinchapi.com/browse/CON-624

I interpreted the point of 
"the purpose of this ticket is to try to avoid eagerly copying the filtered view to a new treemap unless its necessary to do so because the caller is going to modify the returned treemap by adding [a] value that would violate the filter" 
to mean that we should only create a new map in the circumstance that we break the filter by doing some operation, which means checking the new value against the filter in every possible `Map` operation that has the potential to add/replace a value.

Another important point is it was said "only copy the content to another collection if an operation is requested that will be invalid in the view". I interpreted "validity" to mean something that adheres to the filter.

Let me know if I interpreted anything incorrectly! 

The only thing this protects is references to map that's passed in, which I assume was the intent. 