### PR TITLE
Optimize ByteBuffers#getByteArray to avoid copying bytes when it is not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Version 1.12.1 (TBD)
 * Fixed a bug in `AnyStrings#tryParseNumber` that caused an error to be thrown instead of returning `null` when parsing strings with a leading `E` or `e` followed by digit characters (e.g. `e45`). These strings were mistaken for a number in scientific notation, but the parser has been fixed so that error no longer occurs.
+* Optimized `ByteBuffers#getByteArray` to return the backing array of a `ByteBuffer` if it exists and the position of the `ByteBuffer` is `0` as well as the number of bytes `remaining` being equal to its `capacity`.
 
 #### Version 1.12.0 (December 8, 2020)
 * Fixed a bug that made it possible for the `ByteBuffer` returend from `ByteBuffers#get(ByteBuffer int)` to have a different byte order than the input source.

--- a/src/main/java/com/cinchapi/common/io/ByteBuffers.java
+++ b/src/main/java/com/cinchapi/common/io/ByteBuffers.java
@@ -87,8 +87,7 @@ public abstract class ByteBuffers {
      *         {@code buffer}.
      */
     public static byte[] getByteArray(ByteBuffer buffer) {
-        if(buffer.hasArray() && buffer.position() == 0
-                && buffer.remaining() == buffer.capacity()) {
+        if(buffer.hasArray() && buffer.remaining() == buffer.capacity()) {
             return buffer.array();
         }
         else {

--- a/src/main/java/com/cinchapi/common/io/ByteBuffers.java
+++ b/src/main/java/com/cinchapi/common/io/ByteBuffers.java
@@ -87,11 +87,17 @@ public abstract class ByteBuffers {
      *         {@code buffer}.
      */
     public static byte[] getByteArray(ByteBuffer buffer) {
-        buffer.mark();
-        byte[] array = new byte[buffer.remaining()];
-        buffer.get(array);
-        buffer.reset();
-        return array;
+        if(buffer.hasArray() && buffer.position() == 0
+                && buffer.remaining() == buffer.capacity()) {
+            return buffer.array();
+        }
+        else {
+            buffer.mark();
+            byte[] array = new byte[buffer.remaining()];
+            buffer.get(array);
+            buffer.reset();
+            return array;
+        }
     }
 
     /**

--- a/src/test/java/com/cinchapi/common/io/ByteBuffersTest.java
+++ b/src/test/java/com/cinchapi/common/io/ByteBuffersTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2013-2021 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.common.io;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link ByteBuffers}.
+ *
+ * @author Jeff Nelson
+ */
+public class ByteBuffersTest {
+    
+    @Test
+    public void testGetByteArrayFromByteBufferWithBackingArray() {
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(17);
+        buffer.flip();
+        Assert.assertSame(buffer.array(), ByteBuffers.getByteArray(buffer));
+    }
+    
+    @Test
+    public void testGetByteBufferFromBufferWithBackingArraySubset() {
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(17);
+        buffer.flip();
+        buffer.getInt();
+        byte [] bytes = ByteBuffers.getByteArray(buffer);
+        Assert.assertEquals(4, bytes.length);
+        Assert.assertEquals(4, buffer.position());
+        Assert.assertEquals(4, buffer.remaining());
+        buffer.getShort();
+        bytes = ByteBuffers.getByteArray(buffer);
+        Assert.assertEquals(2, bytes.length);
+    }
+    
+    @Test
+    public void testGetByteBufferFromBufferWithoutBackingArray() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(8);
+        buffer.putLong(17);
+        buffer.flip();
+        Assert.assertFalse(buffer.hasArray());
+        byte [] bytes = ByteBuffers.getByteArray(buffer);
+        Assert.assertEquals(ByteBuffer.wrap(bytes), buffer);
+        buffer.getInt();
+        bytes = ByteBuffers.getByteArray(buffer);
+        Assert.assertEquals(4, bytes.length);
+        Assert.assertEquals(4, buffer.position());
+        Assert.assertEquals(4, buffer.remaining());
+        buffer.getShort();
+        bytes = ByteBuffers.getByteArray(buffer);
+        Assert.assertEquals(2, bytes.length);
+    }
+
+}

--- a/src/test/java/com/cinchapi/common/io/ByteBuffersTest.java
+++ b/src/test/java/com/cinchapi/common/io/ByteBuffersTest.java
@@ -51,6 +51,17 @@ public class ByteBuffersTest {
     }
     
     @Test
+    public void testGetByteBufferFromBufferWithBackingArraySubsetPosition() {
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(17);
+        buffer.flip();
+        buffer.position(1);
+        byte[] bytes = ByteBuffers.getByteArray(buffer);
+        Assert.assertNotSame(bytes, buffer.array());
+        Assert.assertEquals(7, bytes.length);
+    }
+    
+    @Test
     public void testGetByteBufferFromBufferWithoutBackingArray() {
         ByteBuffer buffer = ByteBuffer.allocateDirect(8);
         buffer.putLong(17);


### PR DESCRIPTION
…nnecessary to do so