### PR TITLE
Add JoinableExecutorService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 #### Version 1.14.0 (TBD)
-* `JoinableExecutorService`: A new class in the `concurrent` package that enhances a standard `ExecutorService` with capabilities for the calling thread to join task execution. This service allows threads to submit groups of tasks and then participate directly in executing those tasks, aiding in faster completion and improved resource utilization. It ensures tasks are initiated in iteration order but balances task execution across groups to maintain consistent system performance. This feature is beneficial for applications requiring high throughput and dynamic task management.
+* `JoinableExecutorService`: A new class in the `concurrent` package that enhances a standard `ExecutorService` with the ability for the calling thread to join task execution. This service allows threads to submit groups of tasks and then participate directly in executing those tasks, aiding in faster completion and improved resource utilization. It ensures tasks are initiated in iteration order but balances task execution across groups to maintain consistent system performance. This feature is beneficial for applications requiring high throughput and dynamic task management.
 
 #### Version 1.13.1 (October 1, 2022)
 * Fixed a bug that caused a `NoSuchMethodException` to be thrown when using the `Reflection` utility to `call` a non-overriden interface-defined default method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### Version 1.14.0 (TBD)
+* `JoinableExecutorService`: A new class in the `concurrent` package that enhances a standard `ExecutorService` with capabilities for the calling thread to join task execution. This service allows threads to submit groups of tasks and then participate directly in executing those tasks, aiding in faster completion and improved resource utilization. It ensures tasks are initiated in iteration order but balances task execution across groups to maintain consistent system performance. This feature is beneficial for applications requiring high throughput and dynamic task management.
+
 #### Version 1.13.1 (October 1, 2022)
 * Fixed a bug that caused a `NoSuchMethodException` to be thrown when using the `Reflection` utility to `call` a non-overriden interface-defined default method.
 

--- a/src/main/java/com/cinchapi/common/concurrent/JoinableExecutorService.java
+++ b/src/main/java/com/cinchapi/common/concurrent/JoinableExecutorService.java
@@ -277,7 +277,6 @@ public class JoinableExecutorService extends AbstractExecutorService {
                 catch (ExecutionException e) {
                     Runnable t = tasks[i];
                     errorHandler.accept(t, e);
-                    throw CheckedExceptions.wrapAsRuntimeException(e);
                 }
                 catch (InterruptedException e) {
                     Thread.currentThread().interrupt();

--- a/src/main/java/com/cinchapi/common/concurrent/JoinableExecutorService.java
+++ b/src/main/java/com/cinchapi/common/concurrent/JoinableExecutorService.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2013-2024 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.common.concurrent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import com.cinchapi.common.base.CheckedExceptions;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A {@link JoinableExecutorService} provides asynchronous execution of task
+ * groups with an option for the calling thread to {@link #join(Runnable...)
+ * join} and participate in executing its group's tasks while awaiting their
+ * completion.
+ * <p>
+ * This {@link ExecutorService} acts as a shared resource for multiple
+ * processes, enabling each to execute a group of subtasks. It uniquely allows
+ * the calling threads of these processes to contribute actively in executing
+ * the tasks they submitted, facilitating faster completion and efficient use of
+ * resources.
+ * </p>
+ * <p>
+ * When a group of tasks is submitted, they are <strong>initiated</strong> in
+ * iteration order. However, this {@link ExecutorService} strives to balance the
+ * distribution of progress across all groups to maintain consistency in overall
+ * system performance. So, internal worker threads tend to execute tasks across
+ * groups in a breadth-first manner.
+ * </p>
+ *
+ * @author Jeff Nelson
+ */
+public class JoinableExecutorService extends AbstractExecutorService {
+    
+    /**
+     * The underlying {@link ExecutorService} that provides and manages each
+     * worker thread.
+     */
+    private final ExecutorService workers;
+
+    /**
+     * The task groups that have been {@link #submit(BlockingQueue) submitted}.
+     */
+    private final BlockingQueue<BlockingQueue<? extends Runnable>> groups;
+
+    /**
+     * The state of the executor.
+     */
+    private AtomicReference<State> state;
+
+    /**
+     * Construct a new instance.
+     * 
+     * @param numWorkerThreads
+     */
+    public JoinableExecutorService(int numWorkerThreads) {
+        this(numWorkerThreads, Executors.defaultThreadFactory());
+    }
+
+    /**
+     * Construct a new instance.
+     * 
+     * @param numWorkerThreads
+     * @param threadFactory
+     */
+    public JoinableExecutorService(int numWorkerThreads,
+            ThreadFactory threadFactory) {
+        this.groups = new LinkedBlockingQueue<>();
+        this.workers = Executors.newFixedThreadPool(numWorkerThreads,
+                threadFactory);
+        this.state = new AtomicReference<>(State.RUNNING);
+        for (int i = 0; i < numWorkerThreads; ++i) {
+            workers.execute(() -> {
+                for (;;) {
+                    if(state.compareAndSet(State.TERMINATED,
+                            State.TERMINATED)) {
+                        break;
+                    }
+                    else {
+                        BlockingQueue<? extends Runnable> group;
+                        if(state.compareAndSet(State.SHUTDOWN,
+                                State.SHUTDOWN)) {
+                            group = groups.poll();
+                            if(group == null) {
+                                break;
+                            }
+                        }
+                        else {
+                            try {
+                                group = groups.take();
+                            }
+                            catch (InterruptedException e) {
+                                // Interrupt signals a request to shutdown or
+                                // shutdownNow. In either case, re-loop and
+                                // check the #state. If an immediate halt is
+                                // required, the internal task queue will be
+                                // emptied and we don't have to worry here
+                                Thread.currentThread().interrupt();
+                                continue;
+                            }
+                        }
+                        Runnable task = group.poll();
+                        if(task != null) {
+                            run(task);
+                            if(state.compareAndSet(State.SHUTDOWN,
+                                    State.SHUTDOWN)) {
+                                // Since we are shutting down, just complete all
+                                // the tasks in the group and be done
+                                while ((task = group.poll()) != null) {
+                                    run(task);
+                                }
+                            }
+                            else {
+                                groups.offer(group);
+                            }
+                        }
+                        else {
+                            // Since part of the contract is that tasks will not
+                            // be added after a queue has been submitted, assume
+                            // that all that work for this group has been done.
+                            continue;
+                        }
+                    }
+                }
+            });
+        }
+
+    }
+
+    /**
+     * Blocks until all tasks have completed execution after a shutdown request
+     * or the current thread is interrupted, whichever
+     * happens first.
+     * 
+     * @return {@code true} if the executor is terminated
+     * @throws InterruptedException
+     */
+    public boolean awaitTermination() throws InterruptedException {
+        return awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return workers.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        if(state.compareAndSet(State.RUNNING, State.RUNNING)) {
+            BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>();
+            queue.add(command);
+            groups.offer(queue);
+        }
+        else {
+            throw new RejectedExecutionException();
+        }
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return workers.isShutdown() && state.get() != State.RUNNING;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return workers.isTerminated() && state.get() == State.TERMINATED
+                && groups.isEmpty();
+    }
+
+    /**
+     * Cause the calling thread to temporarily join this {@link ExecutorService
+     * executor} and assist in executing the provided {@code tasks}.
+     * <p>
+     * Similar to all {@link ExecutorService} operations, this will
+     * asynchronously perform each of the {@code tasks}, at some point in the
+     * future. But, in addition, the calling thread will be blocked until all of
+     * them have completed.
+     * </p>
+     * <p>
+     * Each task may execute in a in a pooled thread, or in the calling thread.
+     * Because the calling thread participates in execution while waiting, the
+     * affect is that the group of {@code tasks} in completed in at least as
+     * much time as they would be if the calling thread executed them serially
+     * </p>
+     * 
+     * @param errorHandler a {@link BiConsumer} that runs whenever an error
+     *            occurs while executing one of the {@code tasks}.
+     * @param tasks
+     * @return a list of {@link Future} objects that correspond to each of the
+     *         submitted {@code tasks}; since this method awaits completion of
+     *         all tasks, each {@link Future} will be {@link Future#isDone()
+     *         done} and the result can be {@link Future#get() retrieved}
+     *         immediately
+     */
+    @SuppressWarnings("unchecked")
+    public <V> List<Future<V>> join(
+            BiConsumer<Callable<V>, Throwable> errorHandler,
+            Callable<V>... tasks) {
+        Preconditions.checkNotNull(tasks);
+        Preconditions.checkArgument(tasks.length > 0);
+        if(state.compareAndSet(State.RUNNING, State.RUNNING)) {
+            BlockingQueue<FutureTask<V>> queue = new LinkedBlockingQueue<>();
+            List<Future<V>> futures = new ArrayList<>();
+            for (Callable<V> task : tasks) {
+                FutureTask<V> future = new FutureTask<>(task);
+                queue.offer(future);
+                futures.add(future);
+            }
+            groups.offer(queue);
+            FutureTask<V> task;
+            while ((task = queue.poll()) != null) {
+                // Use the calling thread to steal work before waiting for all
+                // the tasks to complete
+                run(task);
+            }
+            for (int i = 0; i < futures.size(); ++i) {
+                Future<V> future = futures.get(i);
+                try {
+                    future.get();
+                }
+                catch (ExecutionException e) {
+                    Callable<V> t = tasks[i];
+                    errorHandler.accept(t, e);
+                    throw CheckedExceptions.wrapAsRuntimeException(e);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return futures;
+        }
+        else {
+            throw new RejectedExecutionException();
+        }
+
+    }
+
+    /**
+     * Cause the calling thread to temporarily join this {@link ExecutorService
+     * executor} and assist in executing the provided {@code tasks}.
+     * <p>
+     * Similar to all {@link ExecutorService} operations, this will
+     * asynchronously perform each of the {@code tasks}, at some point in the
+     * future. But, in addition, the calling thread will be blocked until all of
+     * them have completed.
+     * </p>
+     * <p>
+     * Each task may execute in a in a pooled thread, or in the calling thread.
+     * Because the calling thread participates in execution while waiting, the
+     * affect is that the group of {@code tasks} in completed in at least as
+     * much time as they would be if the calling thread executed them serially
+     * </p>
+     * 
+     * @param errorHandler a {@link BiConsumer} that runs whenever an error
+     *            occurs while executing one of the {@code tasks}.
+     * @param tasks
+     */
+    public void join(BiConsumer<Runnable, Throwable> errorHandler,
+            Runnable... tasks) {
+        Preconditions.checkNotNull(tasks);
+        Preconditions.checkArgument(tasks.length > 0);
+        if(state.compareAndSet(State.RUNNING, State.RUNNING)) {
+            BlockingQueue<FutureTask<Void>> queue = new LinkedBlockingQueue<>();
+            List<Future<Void>> futures = new ArrayList<>();
+            for (Runnable task : tasks) {
+                FutureTask<Void> future = new FutureTask<>(task, null);
+                queue.offer(future);
+                futures.add(future);
+            }
+            groups.offer(queue);
+            Runnable task;
+            while ((task = queue.poll()) != null) {
+                // Use the calling thread to steal work before waiting for all
+                // the tasks to complete
+                run(task);
+            }
+            for (int i = 0; i < futures.size(); ++i) {
+                Future<Void> future = futures.get(i);
+                try {
+                    future.get();
+                }
+                catch (ExecutionException e) {
+                    Runnable t = tasks[i];
+                    errorHandler.accept(t, e);
+                    throw CheckedExceptions.wrapAsRuntimeException(e);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        else {
+            throw new RejectedExecutionException();
+        }
+    }
+
+    /**
+     * Cause the calling thread to temporarily join this {@link ExecutorService
+     * executor} and assist in executing the provided {@code tasks}.
+     * <p>
+     * Similar to all {@link ExecutorService} operations, this will
+     * asynchronously perform each of the {@code tasks}, at some point in the
+     * future. But, in addition, the calling thread will be blocked until all of
+     * them have completed.
+     * </p>
+     * <p>
+     * Each task may execute in a in a pooled thread, or in the calling thread.
+     * Because the calling thread participates in execution while waiting, the
+     * affect is that the group of {@code tasks} in completed in at least as
+     * much time as they would be if the calling thread executed them serially
+     * </p>
+     * 
+     * @param tasks
+     * @return a list of {@link Future} objects that correspond to each of the
+     *         submitted {@code tasks}; since this method awaits completion of
+     *         all tasks, each {@link Future} will be {@link Future#isDone()
+     *         done} and the result can be {@link Future#get() retrived}
+     *         immediately
+     */
+    @SuppressWarnings("unchecked")
+    public <V> List<Future<V>> join(Callable<V>... tasks) {
+        return join((task, error) -> {
+            throw CheckedExceptions.wrapAsRuntimeException(error);
+        }, tasks);
+    }
+
+    /**
+     * Cause the calling thread to temporarily join this {@link ExecutorService
+     * executor} and assist in executing the provided {@code tasks}.
+     * <p>
+     * Similar to all {@link ExecutorService} operations, this will
+     * asynchronously perform each of the {@code tasks}, at some point in the
+     * future. But, in addition, the calling thread will be blocked until all of
+     * them have completed.
+     * </p>
+     * <p>
+     * Each task may execute in a in a pooled thread, or in the calling thread.
+     * Because the calling thread participates in execution while waiting, the
+     * affect is that the group of {@code tasks} in completed in at least as
+     * much time as they would be if the calling thread executed them serially
+     * </p>
+     * 
+     * @param tasks
+     */
+    public void join(Runnable... tasks) {
+        join((task, error) -> {
+            throw CheckedExceptions.wrapAsRuntimeException(error);
+        }, tasks);
+    }
+
+    @Override
+    public void shutdown() {
+        if(state.compareAndSet(State.RUNNING, State.SHUTDOWN)) {
+            workers.shutdownNow();
+            while (!workers.isTerminated()) {
+                continue;
+            }
+            state.compareAndSet(State.SHUTDOWN, State.TERMINATED);
+        }
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        if(state.compareAndSet(State.RUNNING, State.TERMINATED)
+                || state.compareAndSet(State.SHUTDOWN, State.TERMINATED)) {
+            workers.shutdownNow();
+            List<Runnable> unfinished = new ArrayList<>();
+            groups.forEach(group -> group.drainTo(unfinished));
+            groups.clear();
+            return unfinished;
+        }
+        else {
+            return ImmutableList.of();
+        }
+    }
+
+    /**
+     * Execute the {@code task}.
+     * 
+     * @param task
+     */
+    private void run(Runnable task) {
+        if(task instanceof RunnableFuture
+                && !((RunnableFuture<?>) task).isDone()) {
+            // NOTE: Exception handling is automatically
+            // handled by the internals of FutureTask
+            task.run();
+        }
+        else if(task != null) {
+            try {
+                task.run();
+            }
+            catch (Throwable e) {}
+        }
+    }
+
+    /**
+     * Tracks the state of the executor.
+     *
+     * @author Jeff Nelson
+     */
+    private enum State {
+        RUNNING, SHUTDOWN, TERMINATED
+    }
+
+}

--- a/src/test/java/com/cinchapi/common/concurrent/AbstractExecutorServiceTest.java
+++ b/src/test/java/com/cinchapi/common/concurrent/AbstractExecutorServiceTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2013-2024 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.common.concurrent;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for any {@link AbstractExecutorService}.
+ *
+ * @author Jeff Nelson
+ */
+public abstract class AbstractExecutorServiceTest {
+
+    protected ExecutorService executor;
+
+    @Before
+    public void setUp() {
+        executor = $getExecutorService();
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    /**
+     * Return the {@link AbstractExecutorService} to use in these tests.
+     * 
+     * @return the {@link AbstractExecutorService}
+     */
+    protected abstract ExecutorService $getExecutorService();
+
+    @Test
+    public void testExecuteRunnable() throws Exception {
+        AtomicBoolean done = new AtomicBoolean(false);
+        Future<?> future = executor.submit(() -> done.set(true));
+        Assert.assertNull(future.get());
+        Assert.assertNull(future.get(0, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(done.get());
+        Assert.assertTrue(future.isDone());
+        Assert.assertFalse(future.isCancelled());
+    }
+
+    @Test
+    public void testSubmitCallable() throws Exception {
+        String expected = "foo";
+        Future<String> future = executor.submit(() -> expected);
+        String result = future.get();
+        Assert.assertSame(expected, result);
+    }
+
+    @Test
+    public void testSubmitRunnable() throws Exception {
+        Future<?> future = executor.submit(() -> {});
+        future.get();
+        Assert.assertTrue(future.isDone());
+    }
+
+    @Test
+    public void testSubmitRunnableWithFixedResult() throws Exception {
+        Object expected = new Object();
+        Future<?> future = executor.submit(() -> {}, expected);
+        Object result = future.get();
+        Assert.assertTrue(future.isDone());
+        Assert.assertSame(expected, result);
+    }
+
+    @Test(expected = RejectedExecutionException.class)
+    public void testExecuteAfterShutdown() {
+        executor.shutdown();
+        Assert.assertTrue("Executor should be marked as shut down",
+                executor.isShutdown());
+        executor.execute(() -> System.out.println("This should not run"));
+    }
+
+    @Test
+    public void testShutdownTwice() {
+        executor.shutdown();
+        Assert.assertTrue("Executor should be marked as shut down",
+                executor.isShutdown());
+        executor.shutdown(); // Calling shutdown twice to check for idempotence.
+        Assert.assertTrue("Executor should still be marked as shut down",
+                executor.isShutdown());
+    }
+
+    @Test
+    public void testIsTerminated() throws InterruptedException {
+        executor.shutdown();
+        executor.awaitTermination(50, TimeUnit.MILLISECONDS);
+        Assert.assertTrue("Executor should be terminated",
+                executor.isTerminated());
+    }
+
+    @Test
+    public void testIsTerminatedWithoutShutdown() {
+        Assert.assertFalse("Executor should not be terminated before shutdown",
+                executor.isTerminated());
+    }
+
+    @Test
+    public void testAwaitTerminationWithoutShutdown()
+            throws InterruptedException {
+        boolean terminated = executor.awaitTermination(10,
+                TimeUnit.MILLISECONDS);
+        Assert.assertFalse(
+                "Executor service should not terminate since it has not been shut down",
+                terminated);
+    }
+
+}

--- a/src/test/java/com/cinchapi/common/concurrent/AbstractExecutorServiceTest.java
+++ b/src/test/java/com/cinchapi/common/concurrent/AbstractExecutorServiceTest.java
@@ -129,4 +129,11 @@ public abstract class AbstractExecutorServiceTest {
                 terminated);
     }
 
+    @Test(expected = RejectedExecutionException.class)
+    public void testRejectedExecutionAfterShutdown() {
+        executor.shutdown();
+        executor.execute(() -> {});
+        Assert.fail("Expected RejectedExecutionException");
+    }
+
 }

--- a/src/test/java/com/cinchapi/common/concurrent/JoinableExecutorServiceTest.java
+++ b/src/test/java/com/cinchapi/common/concurrent/JoinableExecutorServiceTest.java
@@ -15,6 +15,7 @@
  */
 package com.cinchapi.common.concurrent;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -98,7 +99,6 @@ public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
         }
     }
 
-
     @Test
     public void testIsShutdownAndIsTerminated() throws InterruptedException {
         executor.shutdown();
@@ -111,7 +111,6 @@ public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
         Assert.assertTrue(executor.isTerminated());
     }
 
-
     @Test
     public void testExecuteMultipleTasks() throws InterruptedException {
         JoinableExecutorService executor = (JoinableExecutorService) this.executor;
@@ -123,7 +122,6 @@ public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
         executor.join(commands.build());
         Assert.assertEquals(10, counter.get());
     }
-
 
     @Test
     public void testJoinRunnables() throws Exception {
@@ -145,9 +143,9 @@ public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
             // Ensure that no task was dropped
             Assert.assertEquals(100, map.size());
             Assert.assertEquals(100, count.size());
-            
+
             // Ensure that no task was dropped
-            for(Entry<Integer, AtomicInteger> entry : count.entrySet()) {
+            for (Entry<Integer, AtomicInteger> entry : count.entrySet()) {
                 Assert.assertEquals(1, entry.getValue().get());
             }
         }
@@ -162,7 +160,7 @@ public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
                     "The main thread did not help with any of the work. Possible race condition");
         }
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test
     public void testJoinCallables() throws Exception {
@@ -185,12 +183,12 @@ public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
             // Ensure that no task was dropped
             Assert.assertEquals(100, map.size());
             Assert.assertEquals(100, count.size());
-            
+
             // Ensure that no task was dropped
-            for(Entry<Integer, AtomicInteger> entry : count.entrySet()) {
+            for (Entry<Integer, AtomicInteger> entry : count.entrySet()) {
                 Assert.assertEquals(1, entry.getValue().get());
             }
-            for(Future<Integer> future : futures) {
+            for (Future<Integer> future : futures) {
                 Assert.assertTrue(future.isDone());
             }
         }
@@ -204,6 +202,22 @@ public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
             System.err.println(
                     "The main thread did not help with any of the work. Possible race condition");
         }
+    }
+
+    @Test
+    public void testExceptionHandling() {
+        JoinableExecutorService executor = (JoinableExecutorService) this.executor;
+        AtomicInteger counter = new AtomicInteger();
+
+        List<Runnable> tasks = new ArrayList<>();
+        tasks.add(() -> {
+            throw new IllegalArgumentException("Task 1 exception");
+        });
+        tasks.add(() -> counter.incrementAndGet());
+        executor.join((task, error) -> {
+            counter.incrementAndGet();
+        }, tasks.toArray(new Runnable[0]));
+        Assert.assertEquals(2, counter.get());
     }
 
     @Override

--- a/src/test/java/com/cinchapi/common/concurrent/JoinableExecutorServiceTest.java
+++ b/src/test/java/com/cinchapi/common/concurrent/JoinableExecutorServiceTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2013-2024 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.common.concurrent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.common.base.ArrayBuilder;
+import com.google.common.collect.Lists;
+
+/**
+ * Unit tests for {@link JoinableExecutorService}.
+ *
+ * @author Jeff Nelson
+ */
+public class JoinableExecutorServiceTest extends AbstractExecutorServiceTest {
+
+    @Test
+    public void testSequentialExecutionWithinGroups()
+            throws InterruptedException {
+        JoinableExecutorService service = new JoinableExecutorService(3);
+        List<Integer> results = new CopyOnWriteArrayList<>();
+        ArrayBuilder<Runnable> group1 = ArrayBuilder.builder();
+        group1.add(() -> results.add(1));
+        group1.add(() -> results.add(2));
+
+        ArrayBuilder<Runnable> group2 = ArrayBuilder.builder();
+        group2.add(() -> results.add(3));
+        group2.add(() -> results.add(4));
+
+        service.join(group1.build());
+        service.join(group2.build());
+        service.shutdown();
+        Assert.assertTrue(service.isShutdown());
+
+        service.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+        Assert.assertEquals(4, results.size());
+        List<Boolean> seen = Lists.newArrayList(false, false, false, false,
+                false);
+        for (int i = 0; i < results.size(); ++i) {
+            int result = results.get(i);
+            seen.set(result, true);
+            if(result == 2) {
+                // 2 must have been added after 1
+                Assert.assertTrue(seen.get(1));
+            }
+            else if(result == 4) {
+                // 4 must have been added after 1
+                Assert.assertTrue(seen.get(3));
+            }
+        }
+    }
+
+    @Test
+    public void testBasicTaskExecution() throws Exception {
+        Callable<Integer> task = () -> 123;
+        Future<Integer> future = executor.submit(task);
+        Assert.assertEquals(Integer.valueOf(123), future.get());
+    }
+
+    @Test
+    public void testShutdownBehavior() {
+        executor.shutdown();
+        Assert.assertTrue(executor.isShutdown());
+        try {
+            executor.submit(() -> {});
+            Assert.fail("Should throw exception after shutdown");
+        }
+        catch (RejectedExecutionException e) {
+            // Expected behavior
+        }
+    }
+
+
+    @Test
+    public void testIsShutdownAndIsTerminated() throws InterruptedException {
+        executor.shutdown();
+        Assert.assertTrue(executor.isShutdown());
+
+        // Let any existing tasks finish
+        while (!executor.isTerminated()) {
+            executor.awaitTermination(100, TimeUnit.MILLISECONDS);
+        }
+        Assert.assertTrue(executor.isTerminated());
+    }
+
+
+    @Test
+    public void testExecuteMultipleTasks() throws InterruptedException {
+        JoinableExecutorService executor = (JoinableExecutorService) this.executor;
+        ArrayBuilder<Runnable> commands = ArrayBuilder.builder();
+        AtomicInteger counter = new AtomicInteger(0);
+        for (int i = 0; i < 10; i++) {
+            commands.add(() -> counter.incrementAndGet());
+        }
+        executor.join(commands.build());
+        Assert.assertEquals(10, counter.get());
+    }
+
+
+    @Test
+    public void testJoinRunnables() throws Exception {
+        JoinableExecutorService executor = (JoinableExecutorService) this.executor;
+        Runnable[] tasks = new Runnable[100];
+        Map<Integer, Thread> map = new ConcurrentHashMap<>();
+        Map<Integer, AtomicInteger> count = new ConcurrentHashMap<>();
+        for (int i = 0; i < 100; ++i) {
+            int j = i;
+            tasks[i] = () -> {
+                map.put(j, Thread.currentThread());
+                count.computeIfAbsent(j, $ -> new AtomicInteger(0))
+                        .incrementAndGet();
+            };
+        }
+        executor.join(tasks);
+        Set<Thread> workers = map.values().stream().collect(Collectors.toSet());
+        if(workers.contains(Thread.currentThread()) && workers.size() > 1) {
+            // Ensure that no task was dropped
+            Assert.assertEquals(100, map.size());
+            Assert.assertEquals(100, count.size());
+            
+            // Ensure that no task was dropped
+            for(Entry<Integer, AtomicInteger> entry : count.entrySet()) {
+                Assert.assertEquals(1, entry.getValue().get());
+            }
+        }
+        else if(workers.contains(Thread.currentThread())) {
+            Assert.fail();
+            System.err.println(
+                    "The main thread did all of the work without the executor. Possible race condition");
+        }
+        else {
+            Assert.fail();
+            System.err.println(
+                    "The main thread did not help with any of the work. Possible race condition");
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testJoinCallables() throws Exception {
+        JoinableExecutorService executor = (JoinableExecutorService) this.executor;
+        Callable<Integer>[] tasks = new Callable[100];
+        Map<Integer, Thread> map = new ConcurrentHashMap<>();
+        Map<Integer, AtomicInteger> count = new ConcurrentHashMap<>();
+        for (int i = 0; i < 100; ++i) {
+            int j = i;
+            tasks[i] = () -> {
+                map.put(j, Thread.currentThread());
+                count.computeIfAbsent(j, $ -> new AtomicInteger(0))
+                        .incrementAndGet();
+                return j;
+            };
+        }
+        List<Future<Integer>> futures = executor.join(tasks);
+        Set<Thread> workers = map.values().stream().collect(Collectors.toSet());
+        if(workers.contains(Thread.currentThread()) && workers.size() > 1) {
+            // Ensure that no task was dropped
+            Assert.assertEquals(100, map.size());
+            Assert.assertEquals(100, count.size());
+            
+            // Ensure that no task was dropped
+            for(Entry<Integer, AtomicInteger> entry : count.entrySet()) {
+                Assert.assertEquals(1, entry.getValue().get());
+            }
+            for(Future<Integer> future : futures) {
+                Assert.assertTrue(future.isDone());
+            }
+        }
+        else if(workers.contains(Thread.currentThread())) {
+            Assert.fail();
+            System.err.println(
+                    "The main thread did all of the work without the executor. Possible race condition");
+        }
+        else {
+            Assert.fail();
+            System.err.println(
+                    "The main thread did not help with any of the work. Possible race condition");
+        }
+    }
+
+    @Override
+    protected ExecutorService $getExecutorService() {
+        return new JoinableExecutorService(4);
+    }
+
+}


### PR DESCRIPTION
A new class in the `concurrent` package that enhances the standard `ExecutorService` with capabilities for the calling thread to join task execution. This service allows threads to submit groups of tasks and then participate directly in executing those tasks, aiding in faster completion and improved resource utilization. It ensures tasks are initiated in iteration order but balances task execution across groups to maintain consistent system performance. This feature is beneficial for applications requiring high throughput and dynamic task management.