### PR TITLE
Fix RuntimeDynamics for Java 11+: catch Throwable when defining anonymous classfix

### DIFF
--- a/src/main/java/com/cinchapi/common/unsafe/RuntimeDynamics.java
+++ b/src/main/java/com/cinchapi/common/unsafe/RuntimeDynamics.java
@@ -86,7 +86,9 @@ public final class RuntimeDynamics {
                     bytes.length, null, null);
             return anonymous.newInstance();
         }
-        catch (Exception e) {
+        catch (Throwable e) {
+            // Catch Throwable to handle NoSuchMethodError on Java 11+
+            // where sun.misc.Unsafe.defineClass was removed
             return new Object() {};
         }
     }


### PR DESCRIPTION
## Summary
On Java 11+, `sun.misc.Unsafe.defineClass` was removed. Reflective/anonymous class creation in `RuntimeDynamics` can trigger `NoSuchMethodError` (or other `Error`s) that are not subclasses of `Exception`. Catching only `Exception` leaves these uncaught and can break callers.

## Change
- In `RuntimeDynamics`, broaden the catch from `Exception` to `Throwable` so that `NoSuchMethodError` and other `Error`s during class definition are handled and we fall back to the existing empty anonymous instance as intended.

## Testing
- Existing tests; behavior unchanged on Java 8. On Java 11+, the code path that would throw `NoSuchMethodError` (or similar) now returns the fallback instead of propagating.