### PR TITLE
Fixed a bug in `ByteBuffers#getByteArray` that returned incorrect data for sliced `ByteBuffer` instances. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### Version 1.16.1 (February 22, 2026)
+* Fixed a bug in `ByteBuffers#getByteArray` that returned incorrect data for sliced `ByteBuffer` instances. The fast path incorrectly ignored the buffer's `arrayOffset`, causing it to return the parent buffer's full backing array instead of just the slice's content.
+
 #### Version 1.16.0 (December 18, 2025)
 * Added comprehensive interface reflection utilities to the `Reflection` class for working with Java interfaces and default methods:
   * `getImplementedInterfaces()` - Returns interfaces directly implemented by a class, including interfaces extended by those directly implemented interfaces

--- a/src/main/java/com/cinchapi/common/io/ByteBuffers.java
+++ b/src/main/java/com/cinchapi/common/io/ByteBuffers.java
@@ -87,7 +87,13 @@ public abstract class ByteBuffers {
      *         {@code buffer}.
      */
     public static byte[] getByteArray(ByteBuffer buffer) {
-        if(buffer.hasArray() && buffer.remaining() == buffer.capacity()) {
+        if(buffer.hasArray() && buffer.arrayOffset() == 0
+                && buffer.remaining() == buffer.array().length) {
+            // A sliced ByteBuffer shares the parent's backing array but has a
+            // non-zero arrayOffset, so buffer.array() would return the parent's
+            // full array rather than just the slice's content. Only take the
+            // fast path when the remaining content spans the entire backing
+            // array.
             return buffer.array();
         }
         else {
@@ -406,7 +412,7 @@ public abstract class ByteBuffers {
         buffer.position(oldPosition);
         return slice;
     }
-    
+
     /**
      * Return a new {@link ByteBuffer} whose content is a shared subsequence of
      * the content in {@code buffer} starting at it's current position, for

--- a/src/test/java/com/cinchapi/common/io/ByteBuffersTest.java
+++ b/src/test/java/com/cinchapi/common/io/ByteBuffersTest.java
@@ -62,6 +62,25 @@ public class ByteBuffersTest {
     }
     
     @Test
+    public void testGetByteArrayFromSlicedByteBuffer() {
+        ByteBuffer buffer = ByteBuffer.allocate(9);
+        buffer.put((byte) 0x01);
+        buffer.putLong(17);
+        buffer.flip();
+        buffer.get(); // advance past the first byte
+        ByteBuffer slice = buffer.slice();
+        Assert.assertEquals(8, slice.remaining());
+        Assert.assertEquals(8, slice.capacity());
+        byte[] bytes = ByteBuffers.getByteArray(slice);
+        Assert.assertEquals(8, bytes.length);
+        // Verify the slice content matches, not the parent's array
+        ByteBuffer expected = ByteBuffer.allocate(8);
+        expected.putLong(17);
+        expected.flip();
+        Assert.assertArrayEquals(expected.array(), bytes);
+    }
+
+    @Test
     public void testGetByteBufferFromBufferWithoutBackingArray() {
         ByteBuffer buffer = ByteBuffer.allocateDirect(8);
         buffer.putLong(17);


### PR DESCRIPTION
The fast path incorrectly ignored the buffer's `arrayOffset`, causing it to return the parent buffer's full backing array instead of just the slice's content.